### PR TITLE
chore(monitoring): disable for non web action

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,11 +82,11 @@ jobs:
           command:  WSK_AUTH="$WSK_AUTH_INDEX" npm run deploy-sequences
       # see https://circleci.com/orbs/registry/orb/adobe/helix-post-deploy
       # for more available parameters
-      - helix-post-deploy/monitoring:
-          statuspage_name: Helix Cache Flush Service
-          statuspage_group: Delivery
-          newrelic_group_policy: Delivery Repeated Failure
-          incubator: true # remove only when promoting service to production
+      #- helix-post-deploy/monitoring:
+      #    statuspage_name: Helix Cache Flush Service
+      #    statuspage_group: Delivery
+      #    newrelic_group_policy: Delivery Repeated Failure
+      #    incubator: true # remove only when promoting service to production
 
   branch-deploy:
     executor: node10


### PR DESCRIPTION
We currently support monitoring for web actions only. Support for non web actions would have to be added to https://github.com/adobe/helix-ops
